### PR TITLE
Fix for Russian

### DIFF
--- a/guesslanguage_test.go
+++ b/guesslanguage_test.go
@@ -10,7 +10,7 @@ var parseTests = []struct {
 	{"en", nil, "This is a test of the language checker"},
 	{"fr", nil, "Verifions que le détecteur de langues marche"},
 	{"pl", nil, "Sprawdźmy, czy odgadywacz języków pracuje"},
-	{"ru", nil, "авай проверить  узнает ли наш угадатель русски язык"},
+	{"ru", nil, "Давайте проверим, распознает ли программа русский язык?"},
 	{"es", nil, "La respuesta de los acreedores a la oferta argentina para salir del default no ha sido muy positiv"},
 	{"kk", nil, "Сайлау Сайлау нәтижесінде дауыстардың басым бөлігін ел премьер министрі Виктор Янукович пен оның қарсыласы, оппозиция жетекшісі Виктор Ющенко алды."},
 	{"uz", nil, "милиция ва уч солиқ идораси ходимлари яраланган. Шаҳарда хавфсизлик чоралари кучайтирилган."},


### PR DESCRIPTION
There are mistakes in "авай проверить  узнает ли наш угадатель русски язык". I'd wrote "Давайте проверим, распознает ли программа русский язык?" instead of your one. My sentence translates as "Let's check will the program recognize Russian language?". I glad to say, this is my first pull request to another person for all the time I've been doing programming.
